### PR TITLE
docs: add CONTRIBUTING and CHANGELOG; link from README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [0.1.0] - 2025-08-14
+
+### Added
+- Initial MCP server with:
+  - Tools: echo, auggie_version, auggie_help, auggie_call, project_* helpers, auggie_* orchestration (print/continue/run_file/auth/plan/review)
+  - HTTP streaming (SSE) with health endpoint and mock mode
+  - Safety: repo-root sandboxing, exec gate, validation
+- CI workflow (build, lint, format, test)
+- Tests: compose helpers, SSE positive/negative, search/read safety
+- ESLint (flat) + Prettier + Husky + lint-staged
+
+### Changed
+- Refactored to modern JS (arrow functions, ES modules)
+
+### Fixed
+- SSE heartbeat interval cleanup and duplicate logic removal
+- Path sanitization for auggie_print options
+
+[0.1.0]: https://github.com/rishitank/auggie-mcp/releases/tag/v0.1.0
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,38 @@
+# Contributing to Auggie MCP
+
+Thanks for your interest in contributing! This project uses modern JS/TS, strong linting, and automated tests.
+
+## Ground rules
+
+- Node 24+
+- ES modules only
+- Arrow functions only (no `function` keyword)
+- Keep code safe-by-default; respect env gates (e.g., `AUGGIE_MCP_ALLOW_EXEC`)
+- Sandbox file access under repo root
+
+## Development
+
+- Install deps: `npm ci`
+- Build: `npm run build`
+- Lint: `npm run lint`
+- Format check: `npm run format`
+- Tests: `npm test`
+
+Pre-commit runs lint-staged to auto-fix staged changes.
+
+## Commit style
+
+- Conventional commits preferred (feat:, fix:, docs:, chore:, refactor:, test:)
+- Keep PRs small and focused; include tests
+
+## Pull requests
+
+- Ensure CI is green (build, lint, tests, formatting)
+- Update README/docs when changing behavior
+
+## Security
+
+- Never execute external tools unless `AUGGIE_MCP_ALLOW_EXEC=true`
+- Validate inputs on network endpoints (e.g., `/stream`)
+- Clear intervals/timeouts; avoid leaks
+

--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ An MCP server that wraps the Auggie CLI for agentic code assistance. It exposes 
 - Install Auggie CLI (optional, to enable Auggie tools):
   - `npm install -g @augmentcode/auggie`
 
+- Contributing: see CONTRIBUTING.md
+- Changelog: see CHANGELOG.md
+
 ## Scripts
 
 - Dev: `npm run dev`


### PR DESCRIPTION
This PR adds contributor guidelines and a changelog and links them from the README.

- CONTRIBUTING.md: coding standards, workflow, PR checklist, security notes
- CHANGELOG.md: entries for v0.1.0 (initial release)
- README: CI + ESLint badges already present; added links to contributing/changelog

CI should stay green (docs only).