### PR TITLE
ci: add release workflow (auto-generate notes for tags)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,32 @@
+name: Release
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag name (e.g., v0.1.0)'
+        required: true
+      draft:
+        description: 'Create as a draft release'
+        required: false
+        default: 'false'
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  create-release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Create GitHub Release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.event.inputs.tag || github.ref_name }}
+          release_name: ${{ github.event.inputs.tag || github.ref_name }}
+          draft: ${{ github.event.inputs.draft || 'false' }}
+          generate_release_notes: true
+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,13 +20,13 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v4
-      - name: Create GitHub Release
-        uses: actions/create-release@v1
+      - name: Create GitHub Release (gh)
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ github.event.inputs.tag || github.ref_name }}
-          release_name: ${{ github.event.inputs.tag || github.ref_name }}
-          draft: ${{ github.event.inputs.draft || 'false' }}
-          generate_release_notes: true
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.event.inputs.tag || github.ref_name }}
+          DRAFT: ${{ github.event.inputs.draft || 'false' }}
+        run: |
+          FLAGS=()
+          if [ "${DRAFT}" = "true" ]; then FLAGS+=("--draft"); fi
+          gh release create "${TAG}" --title "${TAG}" --generate-notes "${FLAGS[@]}"
 


### PR DESCRIPTION
Adds a GitHub Actions workflow to generate release notes automatically when a tag is pushed or when manually dispatched.

- Workflow file: .github/workflows/release.yml
- Supports workflow_dispatch with tag input and push on v* tags
- Uses actions/create-release to generate notes

This PR follows repository rules requiring PR-based changes to main.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Introduced an automated release workflow to streamline publishing new versions. Releases can be created from version tags or triggered manually, with release notes generated automatically and an option to publish as draft. This improves consistency, reduces manual steps, and accelerates delivery cadence without changing user-facing functionality. End users benefit from more predictable release timing and clearer change summaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->