### PR TITLE
ci: auto-resolve addressed review suggestions in PRs

### DIFF
--- a/.github/workflows/augment-review-pr.yml
+++ b/.github/workflows/augment-review-pr.yml
@@ -14,10 +14,9 @@ jobs:
     runs-on:
       - ubuntu-latest
     if: github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name && github.event.pull_request.draft == false
-    steps:
     env:
       AUTORESOLVE_LABEL: auto-resolve
-
+    steps:
       - name: Generate PR Review
         uses: augmentcode/review-pr@v0
         with:
@@ -83,12 +82,12 @@ jobs:
               if (!suggestion) continue;
               try {
                 const file = await getFileAtHead(c.path);
-                if (file.includes(suggestion)) {
+                if (suggestion.length > 10 && file.includes(suggestion)) {
                   await gql(resolveThreadMutation, { threadId: t.id });
                   resolved++;
                 }
               } catch (e) {
-                core.warning(`Skip thread due to error: ${e.message}`);
+                core.warning(`Skip thread ${t.id} for path ${c.path}: ${e.message}`);
               }
             }
             core.info(`Auto-resolved ${resolved} review thread(s).`);

--- a/.github/workflows/augment-review-pr.yml
+++ b/.github/workflows/augment-review-pr.yml
@@ -2,7 +2,7 @@ name: Pull Request Review
 
 on:
   pull_request:
-    types: [opened, ready_for_review]
+    types: [opened, ready_for_review, synchronize]
 
 permissions:
   contents: read
@@ -22,3 +22,65 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           pull_number: ${{ github.event.pull_request.number }}
           repo_name: ${{ github.repository }}
+      - name: Auto-resolve addressed suggestions
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const number = context.payload.pull_request.number;
+            const { owner, repo } = context.repo;
+            const gql = (q, v) => github.graphql(q, v);
+
+            const listThreadsQuery = `
+              query($owner: String!, $repo: String!, $number: Int!, $after: String) {
+                repository(owner: $owner, name: $repo) {
+                  pullRequest(number: $number) {
+                    headRefOid
+                    reviewThreads(first: 100, after: $after) {
+                      nodes { id isResolved comments(first: 1) { nodes { body path } } }
+                      pageInfo { hasNextPage endCursor }
+                    }
+                  }
+                }
+              }
+            `;
+            const resolveThreadMutation = `
+              mutation($threadId: ID!) { resolveReviewThread(input: { threadId: $threadId }) { thread { id isResolved } } }
+            `;
+            const getFileAtHead = async (path) => {
+              const headSha = context.payload.pull_request.head.sha;
+              const { data } = await github.request('GET /repos/{owner}/{repo}/contents/{path}', { owner, repo, path, ref: headSha });
+              const buf = Buffer.from(data.content, data.encoding || 'base64');
+              return buf.toString('utf8');
+            };
+            const suggestionRegex = /```suggestion\s*[\r\n]+([\s\S]*?)```/m;
+
+            let threads = [];
+            let after = null;
+            do {
+              const res = await gql(listThreadsQuery, { owner, repo, number, after });
+              const page = res.repository.pullRequest.reviewThreads;
+              threads.push(...page.nodes);
+              after = page.pageInfo.hasNextPage ? page.pageInfo.endCursor : null;
+            } while (after);
+
+            let resolved = 0;
+            for (const t of threads) {
+              if (t.isResolved) continue;
+              const c = t.comments.nodes[0];
+              if (!c || !c.body) continue;
+              const m = c.body.match(suggestionRegex);
+              if (!m) continue; // only auto-resolve suggestion-type comments
+              const suggestion = m[1].trim();
+              if (!suggestion) continue;
+              try {
+                const file = await getFileAtHead(c.path);
+                if (file.includes(suggestion)) {
+                  await gql(resolveThreadMutation, { threadId: t.id });
+                  resolved++;
+                }
+              } catch (e) {
+                core.warning(`Skip thread due to error: ${e.message}`);
+              }
+            }
+            core.info(`Auto-resolved ${resolved} review thread(s).`);
+

--- a/.github/workflows/augment-review-pr.yml
+++ b/.github/workflows/augment-review-pr.yml
@@ -61,10 +61,10 @@ jobs:
             const suggestionRegex = /```suggestion\s*[\r\n]+([\s\S]*?)```/m;
 
             const matchesSuggestion = (file, suggestion) => {
-              if (!suggestion || suggestion.length <= 10) return false;
+              if (!suggestion || suggestion.trim().length === 0) return false;
               const norm = suggestion.replace(/\r\n/g, '\n');
               const lines = norm.split('\n').filter(l => l.trim() !== '');
-              if (lines.length < 2) return false; // require multi-line to avoid trivial matches
+              if (lines.length < 1) return false; // require at least one non-empty line
               const escape = (s) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
               const escaped = lines.map(escape);
               const pattern = escaped.map((l, i) => (i === 0 ? l : '\\s*' + l)).join('\\r?\\n');
@@ -94,15 +94,15 @@ jobs:
               if (!suggestion) continue;
               try {
                 const filePath = t.path;
-                if (!filePath || filePath.includes('..')) {
+                if (!filePath || filePath.includes('..') || filePath.startsWith('/') || filePath.includes('\0')) {
                   core.warning(`Skip thread ${t.id}: invalid or missing path ${filePath}`);
                   continue;
                 }
                 const file = await getFileAtHead(filePath);
                 // Prefer a small window around the thread line(s) to reduce false positives
-                const startLine = t.startLine || t.line;
+                const startLine = t.startLine || t.line || 1;
                 const endLine = t.line || t.startLine || startLine;
-                const window = startLine ? getWindowByLines(file, Math.max(1, startLine - 5), (endLine || startLine) + 5) : null;
+                const window = getWindowByLines(file, Math.max(1, startLine - 5), endLine + 5);
                 const matches = window ? matchesSuggestion(window, suggestion) : matchesSuggestion(file, suggestion);
                 if (matches) {
                   await gql(resolveThreadMutation, { threadId: t.id });

--- a/.github/workflows/augment-review-pr.yml
+++ b/.github/workflows/augment-review-pr.yml
@@ -67,7 +67,7 @@ jobs:
               if (lines.every(l => l.trim() === '')) return false; // require at least one non-empty line overall
               const escape = (s) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
               const escaped = lines.map(escape);
-              const pattern = escaped.map(l => (l.length > 0 ? '^\\s*' + l + '\\s*$' : '^\\s*$')).join('\\s*\\r?\\n');
+              const pattern = escaped.map(l => (l.length > 0 ? '^\\s*' + l + '\\s*$' : '^\\s*$')).join('\\s*\\r?\\n\\s*');
               const re = new RegExp(pattern, 'm');
               if (re.test(file)) return true;
               // Fallback exact check
@@ -105,8 +105,13 @@ jobs:
                 const endLine = t.line || t.startLine || startLine;
                 const fileLinesCount = file.split('\n').length;
                 const window = getWindowByLines(file, Math.max(1, startLine - 5), Math.min(fileLinesCount, endLine + 5));
-                const matches = window ? matchesSuggestion(window, suggestion)
-                                       : (file.length < 50000 ? matchesSuggestion(file, suggestion) : false);
+                let matches = false;
+                if (window) {
+                  matches = matchesSuggestion(window, suggestion);
+                }
+                if (!matches && file.length < 50000) {
+                  matches = matchesSuggestion(file, suggestion);
+                }
                 if (matches) {
                   await gql(resolveThreadMutation, { threadId: t.id });
                   resolved++;

--- a/.github/workflows/augment-review-pr.yml
+++ b/.github/workflows/augment-review-pr.yml
@@ -15,6 +15,9 @@ jobs:
       - ubuntu-latest
     if: github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name && github.event.pull_request.draft == false
     steps:
+    env:
+      AUTORESOLVE_LABEL: auto-resolve
+
       - name: Generate PR Review
         uses: augmentcode/review-pr@v0
         with:
@@ -26,8 +29,14 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const number = context.payload.pull_request.number;
+            const pr = context.payload.pull_request;
+            const number = pr.number;
             const { owner, repo } = context.repo;
+            const gated = (pr.labels || []).some(l => l.name === process.env.AUTORESOLVE_LABEL);
+            if (!gated) {
+              core.info(`Skipping autoresolve; PR lacks label ${process.env.AUTORESOLVE_LABEL}`);
+              return;
+            }
             const gql = (q, v) => github.graphql(q, v);
 
             const listThreadsQuery = `

--- a/.github/workflows/augment-review-pr.yml
+++ b/.github/workflows/augment-review-pr.yml
@@ -36,7 +36,7 @@ jobs:
                 repository(owner: $owner, name: $repo) {
                   pullRequest(number: $number) {
                     reviewThreads(first: 100, after: $after) {
-                      nodes { id isResolved path line startLine comments(first: 1) { nodes { body } } }
+                      nodes { id isResolved path line startLine comments(first: 50) { nodes { body } } }
                       pageInfo { hasNextPage endCursor }
                     }
                   }
@@ -58,7 +58,7 @@ jobs:
               const e = Math.min(lines.length, end || lines.length);
               return lines.slice(s - 1, e).join('\n');
             };
-            const suggestionRegex = /```suggestion\s*[\r\n]+([\s\S]*?)```/m;
+            const suggestionRegex = /```suggestion[^\r\n]*[\r\n]+([\s\S]*?)```/m;
 
             const matchesSuggestion = (file, suggestion) => {
               if (!suggestion || suggestion.trim().length === 0) return false;
@@ -86,11 +86,11 @@ jobs:
             let resolved = 0;
             for (const t of threads) {
               if (t.isResolved) continue;
-              const c = t.comments.nodes[0];
-              if (!c || !c.body) continue;
-              const m = c.body.match(suggestionRegex);
-              if (!m) continue; // only auto-resolve suggestion-type comments
-              const suggestion = m[1].trim();
+              const comments = (t.comments && t.comments.nodes) || [];
+              const found = comments.find(cm => cm && typeof cm.body === 'string' && suggestionRegex.test(cm.body));
+              if (!found) continue; // only auto-resolve suggestion-type comments
+              const match = found.body.match(suggestionRegex);
+              const suggestion = (match && match[1] ? match[1].trim() : '');
               if (!suggestion) continue;
               try {
                 const filePath = t.path;
@@ -98,7 +98,8 @@ jobs:
                   core.warning(`Skip thread ${t.id}: invalid or missing path ${filePath}`);
                   continue;
                 }
-                const file = await getFileAtHead(filePath);
+                const fileRaw = await getFileAtHead(filePath);
+                const file = fileRaw.replace(/\r\n/g, '\n');
                 // Prefer a small window around the thread line(s) to reduce false positives
                 const startLine = t.startLine || t.line || 1;
                 const endLine = t.line || t.startLine || startLine;

--- a/.github/workflows/augment-review-pr.yml
+++ b/.github/workflows/augment-review-pr.yml
@@ -91,7 +91,8 @@ jobs:
               if (!suggestionComments.length) continue; // only auto-resolve suggestion-type comments
               try {
                 const filePath = t.path;
-                if (!filePath || filePath.includes('..') || filePath.startsWith('/') || filePath.includes('\0')) {
+                const decodedPath = (() => { try { return decodeURIComponent(filePath); } catch { return filePath; } })();
+                if (!filePath || filePath.includes('..') || filePath.startsWith('/') || filePath.includes('\0') || decodedPath.includes('..')) {
                   core.warning(`Skip thread ${t.id}: invalid or missing path ${filePath}`);
                   continue;
                 }
@@ -113,7 +114,7 @@ jobs:
                     if (window) {
                       matches = matchesSuggestion(window, suggestion);
                     }
-                    if (!matches && file.length < 50000) {
+                    if (!matches && file.length < 100000) {
                       matches = matchesSuggestion(file, suggestion);
                     }
                     if (matches) { threadMatches = true; break; }
@@ -130,7 +131,7 @@ jobs:
                   core.warning(`Skip thread ${t.id}: file not found at path ${t.path}`);
                 } else {
                   core.error(`Failed to process thread ${t.id} for path ${t.path}: ${e?.message}`);
-                  throw e;
+                  continue; // log and skip this thread
                 }
               }
             }

--- a/.github/workflows/augment-review-pr.yml
+++ b/.github/workflows/augment-review-pr.yml
@@ -67,7 +67,7 @@ jobs:
               if (lines.every(l => l.trim() === '')) return false; // require at least one non-empty line overall
               const escape = (s) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
               const escaped = lines.map(escape);
-              const pattern = escaped.map(l => '^\\s*' + l).join('\\s*\\r?\\n');
+              const pattern = escaped.map(l => (l.length > 0 ? '^\\s*' + l + '\\s*$' : '^\\s*$')).join('\\s*\\r?\\n');
               const re = new RegExp(pattern, 'm');
               if (re.test(file)) return true;
               // Fallback exact check
@@ -106,7 +106,7 @@ jobs:
                 const fileLinesCount = file.split('\n').length;
                 const window = getWindowByLines(file, Math.max(1, startLine - 5), Math.min(fileLinesCount, endLine + 5));
                 const matches = window ? matchesSuggestion(window, suggestion)
-                                       : (file.length < 10000 ? matchesSuggestion(file, suggestion) : false);
+                                       : (file.length < 50000 ? matchesSuggestion(file, suggestion) : false);
                 if (matches) {
                   await gql(resolveThreadMutation, { threadId: t.id });
                   resolved++;

--- a/.github/workflows/augment-review-pr.yml
+++ b/.github/workflows/augment-review-pr.yml
@@ -60,12 +60,6 @@ jobs:
             };
             const suggestionRegex = /```suggestion\s*[\r\n]+([\s\S]*?)```/m;
 
-            let threads = [];
-            let after = null;
-            do {
-              const res = await gql(listThreadsQuery, { owner, repo, number, after });
-              const page = res.repository.pullRequest.reviewThreads;
-              threads.push(...page.nodes);
             const matchesSuggestion = (file, suggestion) => {
               if (!suggestion || suggestion.length <= 10) return false;
               const norm = suggestion.replace(/\r\n/g, '\n');
@@ -80,6 +74,12 @@ jobs:
               return file.includes(norm);
             };
 
+            let threads = [];
+            let after = null;
+            do {
+              const res = await gql(listThreadsQuery, { owner, repo, number, after });
+              const page = res.repository.pullRequest.reviewThreads;
+              threads.push(...page.nodes);
               after = page.pageInfo.hasNextPage ? page.pageInfo.endCursor : null;
             } while (after);
 
@@ -93,7 +93,11 @@ jobs:
               const suggestion = m[1].trim();
               if (!suggestion) continue;
               try {
-                const filePath = t.path || c.path;
+                const filePath = t.path;
+                if (!filePath || filePath.includes('..')) {
+                  core.warning(`Skip thread ${t.id}: invalid or missing path ${filePath}`);
+                  continue;
+                }
                 const file = await getFileAtHead(filePath);
                 // Prefer a small window around the thread line(s) to reduce false positives
                 const startLine = t.startLine || t.line;
@@ -105,8 +109,12 @@ jobs:
                   resolved++;
                 }
               } catch (e) {
-                const fp = (t && (t.path || (c && c.path))) || '?';
-                core.warning(`Skip thread ${t.id} for path ${fp}: ${e.message}`);
+                if (e?.status === 404) {
+                  core.warning(`Skip thread ${t.id}: file not found at path ${t.path}`);
+                } else {
+                  core.error(`Failed to process thread ${t.id} for path ${t.path}: ${e?.message}`);
+                  throw e;
+                }
               }
             }
             core.info(`Auto-resolved ${resolved} review thread(s).`);

--- a/.github/workflows/augment-review-pr.yml
+++ b/.github/workflows/augment-review-pr.yml
@@ -61,6 +61,20 @@ jobs:
               const res = await gql(listThreadsQuery, { owner, repo, number, after });
               const page = res.repository.pullRequest.reviewThreads;
               threads.push(...page.nodes);
+            const matchesSuggestion = (file, suggestion) => {
+              if (!suggestion || suggestion.length <= 10) return false;
+              const norm = suggestion.replace(/\r\n/g, '\n');
+              const lines = norm.split('\n').filter(l => l.trim() !== '');
+              if (lines.length < 2) return false; // require multi-line to avoid trivial matches
+              const escape = (s) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+              const escaped = lines.map(escape);
+              const pattern = escaped.map((l, i) => (i === 0 ? l : '\\s*' + l)).join('\\r?\\n');
+              const re = new RegExp(pattern, 'm');
+              if (re.test(file)) return true;
+              // Fallback exact check
+              return file.includes(norm);
+            };
+
               after = page.pageInfo.hasNextPage ? page.pageInfo.endCursor : null;
             } while (after);
 
@@ -75,7 +89,7 @@ jobs:
               if (!suggestion) continue;
               try {
                 const file = await getFileAtHead(c.path);
-                if (suggestion.length > 10 && suggestion.split('\n').length > 1 && file.includes(suggestion)) {
+                if (matchesSuggestion(file, suggestion)) {
                   await gql(resolveThreadMutation, { threadId: t.id });
                   resolved++;
                 }

--- a/.github/workflows/augment-review-pr.yml
+++ b/.github/workflows/augment-review-pr.yml
@@ -58,7 +58,7 @@ jobs:
               const e = Math.min(lines.length, end || lines.length);
               return lines.slice(s - 1, e).join('\n');
             };
-            const suggestionRegex = /```suggestion[^\r\n]*[\r\n]+([\s\S]*?)```/m;
+            const suggestionRegex = /```suggestion[^\r\n]*[\r\n]+([\s\S]*?)```/gm;
 
             const matchesSuggestion = (file, suggestion) => {
               if (!suggestion || suggestion.trim().length === 0) return false;
@@ -87,11 +87,8 @@ jobs:
             for (const t of threads) {
               if (t.isResolved) continue;
               const comments = (t.comments && t.comments.nodes) || [];
-              const found = comments.find(cm => cm && typeof cm.body === 'string' && suggestionRegex.test(cm.body));
-              if (!found) continue; // only auto-resolve suggestion-type comments
-              const match = found.body.match(suggestionRegex);
-              const suggestion = (match && match[1] ? match[1].trim() : '');
-              if (!suggestion) continue;
+              const suggestionComments = comments.filter(cm => cm && typeof cm.body === 'string' && suggestionRegex.test(cm.body));
+              if (!suggestionComments.length) continue; // only auto-resolve suggestion-type comments
               try {
                 const filePath = t.path;
                 if (!filePath || filePath.includes('..') || filePath.startsWith('/') || filePath.includes('\0')) {
@@ -105,14 +102,26 @@ jobs:
                 const endLine = t.line || t.startLine || startLine;
                 const fileLinesCount = file.split('\n').length;
                 const window = getWindowByLines(file, Math.max(1, startLine - 5), Math.min(fileLinesCount, endLine + 5));
-                let matches = false;
-                if (window) {
-                  matches = matchesSuggestion(window, suggestion);
+
+                let threadMatches = false;
+                for (const comment of suggestionComments) {
+                  const all = [...comment.body.matchAll(suggestionRegex)];
+                  for (const m of all) {
+                    const suggestion = (m && m[1] ? m[1].trim() : '');
+                    if (!suggestion) continue;
+                    let matches = false;
+                    if (window) {
+                      matches = matchesSuggestion(window, suggestion);
+                    }
+                    if (!matches && file.length < 50000) {
+                      matches = matchesSuggestion(file, suggestion);
+                    }
+                    if (matches) { threadMatches = true; break; }
+                  }
+                  if (threadMatches) break;
                 }
-                if (!matches && file.length < 50000) {
-                  matches = matchesSuggestion(file, suggestion);
-                }
-                if (matches) {
+
+                if (threadMatches) {
                   await gql(resolveThreadMutation, { threadId: t.id });
                   resolved++;
                 }

--- a/.github/workflows/augment-review-pr.yml
+++ b/.github/workflows/augment-review-pr.yml
@@ -35,9 +35,8 @@ jobs:
               query($owner: String!, $repo: String!, $number: Int!, $after: String) {
                 repository(owner: $owner, name: $repo) {
                   pullRequest(number: $number) {
-                    headRefOid
                     reviewThreads(first: 100, after: $after) {
-                      nodes { id isResolved comments(first: 1) { nodes { body path } } }
+                      nodes { id isResolved path line startLine comments(first: 1) { nodes { body } } }
                       pageInfo { hasNextPage endCursor }
                     }
                   }
@@ -52,6 +51,12 @@ jobs:
               const { data } = await github.request('GET /repos/{owner}/{repo}/contents/{path}', { owner, repo, path, ref: headSha });
               const buf = Buffer.from(data.content, data.encoding || 'base64');
               return buf.toString('utf8');
+            };
+            const getWindowByLines = (text, start, end) => {
+              const lines = text.split('\n');
+              const s = Math.max(1, start || 1);
+              const e = Math.min(lines.length, end || lines.length);
+              return lines.slice(s - 1, e).join('\n');
             };
             const suggestionRegex = /```suggestion\s*[\r\n]+([\s\S]*?)```/m;
 
@@ -88,13 +93,20 @@ jobs:
               const suggestion = m[1].trim();
               if (!suggestion) continue;
               try {
-                const file = await getFileAtHead(c.path);
-                if (matchesSuggestion(file, suggestion)) {
+                const filePath = t.path || c.path;
+                const file = await getFileAtHead(filePath);
+                // Prefer a small window around the thread line(s) to reduce false positives
+                const startLine = t.startLine || t.line;
+                const endLine = t.line || t.startLine || startLine;
+                const window = startLine ? getWindowByLines(file, Math.max(1, startLine - 5), (endLine || startLine) + 5) : null;
+                const matches = window ? matchesSuggestion(window, suggestion) : matchesSuggestion(file, suggestion);
+                if (matches) {
                   await gql(resolveThreadMutation, { threadId: t.id });
                   resolved++;
                 }
               } catch (e) {
-                core.warning(`Skip thread ${t.id} for path ${c.path}: ${e.message}`);
+                const fp = (t && (t.path || (c && c.path))) || '?';
+                core.warning(`Skip thread ${t.id} for path ${fp}: ${e.message}`);
               }
             }
             core.info(`Auto-resolved ${resolved} review thread(s).`);

--- a/.github/workflows/augment-review-pr.yml
+++ b/.github/workflows/augment-review-pr.yml
@@ -58,7 +58,8 @@ jobs:
               const e = Math.min(lines.length, end || lines.length);
               return lines.slice(s - 1, e).join('\n');
             };
-            const suggestionRegex = /```suggestion[^\r\n]*[\r\n]+([\s\S]*?)```/gm;
+            const suggestionPattern = '```suggestion[^\\r\\n]*[\\r\\n]+([\\s\\S]*?)```';
+            const suggestionReSingle = new RegExp(suggestionPattern, 'm');
 
             const matchesSuggestion = (file, suggestion) => {
               if (!suggestion || suggestion.trim().length === 0) return false;
@@ -87,7 +88,7 @@ jobs:
             for (const t of threads) {
               if (t.isResolved) continue;
               const comments = (t.comments && t.comments.nodes) || [];
-              const suggestionComments = comments.filter(cm => cm && typeof cm.body === 'string' && suggestionRegex.test(cm.body));
+              const suggestionComments = comments.filter(cm => cm && typeof cm.body === 'string' && new RegExp(suggestionPattern, 'm').test(cm.body));
               if (!suggestionComments.length) continue; // only auto-resolve suggestion-type comments
               try {
                 const filePath = t.path;
@@ -106,7 +107,7 @@ jobs:
 
                 let threadMatches = false;
                 for (const comment of suggestionComments) {
-                  const all = [...comment.body.matchAll(suggestionRegex)];
+                  const all = [...comment.body.matchAll(new RegExp(suggestionPattern, 'gm'))];
                   for (const m of all) {
                     const suggestion = (m && m[1] ? m[1].trim() : '');
                     if (!suggestion) continue;

--- a/.github/workflows/augment-review-pr.yml
+++ b/.github/workflows/augment-review-pr.yml
@@ -14,8 +14,6 @@ jobs:
     runs-on:
       - ubuntu-latest
     if: github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name && github.event.pull_request.draft == false
-    env:
-      AUTORESOLVE_LABEL: auto-resolve
     steps:
       - name: Generate PR Review
         uses: augmentcode/review-pr@v0
@@ -31,11 +29,6 @@ jobs:
             const pr = context.payload.pull_request;
             const number = pr.number;
             const { owner, repo } = context.repo;
-            const gated = (pr.labels || []).some(l => l.name === process.env.AUTORESOLVE_LABEL);
-            if (!gated) {
-              core.info(`Skipping autoresolve; PR lacks label ${process.env.AUTORESOLVE_LABEL}`);
-              return;
-            }
             const gql = (q, v) => github.graphql(q, v);
 
             const listThreadsQuery = `
@@ -82,7 +75,7 @@ jobs:
               if (!suggestion) continue;
               try {
                 const file = await getFileAtHead(c.path);
-                if (suggestion.length > 10 && file.includes(suggestion)) {
+                if (suggestion.length > 10 && suggestion.split('\n').length > 1 && file.includes(suggestion)) {
                   await gql(resolveThreadMutation, { threadId: t.id });
                   resolved++;
                 }

--- a/.github/workflows/augment-review-pr.yml
+++ b/.github/workflows/augment-review-pr.yml
@@ -58,8 +58,8 @@ jobs:
               const e = Math.min(lines.length, end || lines.length);
               return lines.slice(s - 1, e).join('\n');
             };
+            // Matches ```suggestion [lang]\n...``` blocks (single or multiple)
             const suggestionPattern = '```suggestion[^\\r\\n]*[\\r\\n]+([\\s\\S]*?)```';
-            const suggestionReSingle = new RegExp(suggestionPattern, 'm');
 
             const matchesSuggestion = (file, suggestion) => {
               if (!suggestion || suggestion.trim().length === 0) return false;
@@ -68,7 +68,8 @@ jobs:
               if (lines.every(l => l.trim() === '')) return false; // require at least one non-empty line overall
               const escape = (s) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
               const escaped = lines.map(escape);
-              const pattern = escaped.map(l => (l.length > 0 ? '^\\s*' + l + '\\s*$' : '^\\s*$')).join('\\s*\\r?\\n\\s*');
+              const buildPatternFromLines = (ls) => ls.map(l => (l.length > 0 ? '^\\s*' + l + '\\s*$' : '^\\s*$')).join('\\s*\\r?\\n\\s*');
+              const pattern = buildPatternFromLines(escaped);
               const re = new RegExp(pattern, 'm');
               if (re.test(file)) return true;
               // Fallback exact check
@@ -115,7 +116,8 @@ jobs:
                     if (window) {
                       matches = matchesSuggestion(window, suggestion);
                     }
-                    if (!matches && file.length < 100000) {
+                    const MAX_FILE_SIZE_FOR_FULL_SCAN = 100000; // 100KB limit to avoid performance issues
+                    if (!matches && file.length < MAX_FILE_SIZE_FOR_FULL_SCAN) {
                       matches = matchesSuggestion(file, suggestion);
                     }
                     if (matches) { threadMatches = true; break; }

--- a/.github/workflows/augment-review-pr.yml
+++ b/.github/workflows/augment-review-pr.yml
@@ -63,11 +63,11 @@ jobs:
             const matchesSuggestion = (file, suggestion) => {
               if (!suggestion || suggestion.trim().length === 0) return false;
               const norm = suggestion.replace(/\r\n/g, '\n');
-              const lines = norm.split('\n').filter(l => l.trim() !== '');
-              if (lines.length < 1) return false; // require at least one non-empty line
+              const lines = norm.split('\n').map(l => l.replace(/\s+$/, ''));
+              if (lines.every(l => l.trim() === '')) return false; // require at least one non-empty line overall
               const escape = (s) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
               const escaped = lines.map(escape);
-              const pattern = escaped.map((l, i) => (i === 0 ? l : '\\s*' + l)).join('\\r?\\n');
+              const pattern = escaped.map(l => '^\\s*' + l).join('\\s*\\r?\\n');
               const re = new RegExp(pattern, 'm');
               if (re.test(file)) return true;
               // Fallback exact check
@@ -103,8 +103,10 @@ jobs:
                 // Prefer a small window around the thread line(s) to reduce false positives
                 const startLine = t.startLine || t.line || 1;
                 const endLine = t.line || t.startLine || startLine;
-                const window = getWindowByLines(file, Math.max(1, startLine - 5), endLine + 5);
-                const matches = window ? matchesSuggestion(window, suggestion) : matchesSuggestion(file, suggestion);
+                const fileLinesCount = file.split('\n').length;
+                const window = getWindowByLines(file, Math.max(1, startLine - 5), Math.min(fileLinesCount, endLine + 5));
+                const matches = window ? matchesSuggestion(window, suggestion)
+                                       : (file.length < 10000 ? matchesSuggestion(file, suggestion) : false);
                 if (matches) {
                   await gql(resolveThreadMutation, { threadId: t.id });
                   resolved++;

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,6 @@ jobs:
         run: |
           FLAGS=()
           if [ "${DRAFT}" = "true" ]; then FLAGS+=("--draft"); fi
-          if [[ ! "${TAG}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+.*$ ]]; then echo "Invalid tag format: ${TAG}. Expected format: v1.2.3"; exit 1; fi
+          if [[ ! "${TAG}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.-]+)?(\+[A-Za-z0-9.-]+)?$ ]]; then echo "Invalid tag format: ${TAG}. Expected format: v1.2.3 or v1.2.3-alpha.1"; exit 1; fi
           gh release view "${TAG}" >/dev/null 2>&1 && { echo "Release ${TAG} already exists. Skipping creation."; exit 0; }
           gh release create "${TAG}" --title "${TAG}" --generate-notes "${FLAGS[@]}" || { echo "Failed to create release ${TAG}. Check if tag exists or permissions are missing."; exit 1; }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,32 @@
+name: Release
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag name (e.g., v0.1.0)'
+        required: true
+      draft:
+        description: 'Create as a draft release'
+        required: false
+        default: 'false'
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  create-release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Create GitHub Release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.event.inputs.tag || github.ref_name }}
+          release_name: ${{ github.event.inputs.tag || github.ref_name }}
+          draft: ${{ github.event.inputs.draft || 'false' }}
+          generate_release_notes: true
+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,5 +28,5 @@ jobs:
         run: |
           FLAGS=()
           if [ "${DRAFT}" = "true" ]; then FLAGS+=("--draft"); fi
-          gh release create "${TAG}" --title "${TAG}" --generate-notes ${FLAGS[*]}
+          gh release create "${TAG}" --title "${TAG}" --generate-notes "${FLAGS[@]}"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,5 +28,5 @@ jobs:
         run: |
           FLAGS=()
           if [ "${DRAFT}" = "true" ]; then FLAGS+=("--draft"); fi
-          gh release create "${TAG}" --title "${TAG}" --generate-notes "${FLAGS[@]}" || { echo "Failed to create release ${TAG}"; exit 1; }
+          gh release create "${TAG}" --title "${TAG}" --generate-notes "${FLAGS[@]}" || { echo "Failed to create release ${TAG}. Check if tag exists or permissions are missing."; exit 1; }
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,5 +28,5 @@ jobs:
         run: |
           FLAGS=()
           if [ "${DRAFT}" = "true" ]; then FLAGS+=("--draft"); fi
-          gh release create "${TAG}" --title "${TAG}" --generate-notes "${FLAGS[@]}"
+          gh release create "${TAG}" --title "${TAG}" --generate-notes ${FLAGS[*]}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,8 @@ jobs:
         run: |
           FLAGS=()
           if [ "${DRAFT}" = "true" ]; then FLAGS+=("--draft"); fi
-          if [[ ! "${TAG}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.-]+)?(\+[A-Za-z0-9.-]+)?$ ]]; then echo "Invalid tag format: ${TAG}. Expected semantic version format: v1.2.3, v1.2.3-alpha.1, or v1.2.3+build.1"; exit 1; fi
+          # Validate semantic version format: v1.2.3, v1.2.3-alpha.1, or v1.2.3+build.1
+          SEMVER_PATTERN='^v[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.-]+)?(\+[A-Za-z0-9.-]+)?$'
+          if [[ ! "${TAG}" =~ $SEMVER_PATTERN ]]; then echo "Invalid tag format: ${TAG}. Expected semantic version format: v1.2.3, v1.2.3-alpha.1, or v1.2.3+build.1"; exit 1; fi
           gh release view "${TAG}" >/dev/null 2>&1 && { echo "Release ${TAG} already exists. Skipping creation." >&2; exit 0; }
           gh release create "${TAG}" --title "${TAG}" --generate-notes "${FLAGS[@]}" || { echo "Failed to create release ${TAG}. Check if tag exists or permissions are missing."; exit 1; }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,4 +29,3 @@ jobs:
           FLAGS=()
           if [ "${DRAFT}" = "true" ]; then FLAGS+=("--draft"); fi
           gh release create "${TAG}" --title "${TAG}" --generate-notes "${FLAGS[@]}" || { echo "Failed to create release ${TAG}. Check if tag exists or permissions are missing."; exit 1; }
-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,4 +28,6 @@ jobs:
         run: |
           FLAGS=()
           if [ "${DRAFT}" = "true" ]; then FLAGS+=("--draft"); fi
+          if [[ ! "${TAG}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+.*$ ]]; then echo "Invalid tag format: ${TAG}. Expected format: v1.2.3"; exit 1; fi
+          gh release view "${TAG}" >/dev/null 2>&1 && { echo "Release ${TAG} already exists. Skipping creation."; exit 0; }
           gh release create "${TAG}" --title "${TAG}" --generate-notes "${FLAGS[@]}" || { echo "Failed to create release ${TAG}. Check if tag exists or permissions are missing."; exit 1; }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,13 +20,13 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v4
-      - name: Create GitHub Release
-        uses: actions/create-release@v1
+      - name: Create GitHub Release (gh)
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ github.event.inputs.tag || github.ref_name }}
-          release_name: ${{ github.event.inputs.tag || github.ref_name }}
-          draft: ${{ github.event.inputs.draft || 'false' }}
-          generate_release_notes: true
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.event.inputs.tag || github.ref_name }}
+          DRAFT: ${{ github.event.inputs.draft || 'false' }}
+        run: |
+          FLAGS=()
+          if [ "${DRAFT}" = "true" ]; then FLAGS+=("--draft"); fi
+          gh release create "${TAG}" --title "${TAG}" --generate-notes "${FLAGS[@]}"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,5 +28,5 @@ jobs:
         run: |
           FLAGS=()
           if [ "${DRAFT}" = "true" ]; then FLAGS+=("--draft"); fi
-          gh release create "${TAG}" --title "${TAG}" --generate-notes "${FLAGS[@]}"
+          gh release create "${TAG}" --title "${TAG}" --generate-notes "${FLAGS[@]}" || { echo "Failed to create release ${TAG}"; exit 1; }
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,5 +29,5 @@ jobs:
           FLAGS=()
           if [ "${DRAFT}" = "true" ]; then FLAGS+=("--draft"); fi
           if [[ ! "${TAG}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.-]+)?(\+[A-Za-z0-9.-]+)?$ ]]; then echo "Invalid tag format: ${TAG}. Expected semantic version format: v1.2.3, v1.2.3-alpha.1, or v1.2.3+build.1"; exit 1; fi
-          gh release view "${TAG}" >/dev/null 2>&1 && { echo "Release ${TAG} already exists. Skipping creation."; exit 0; }
+          gh release view "${TAG}" >/dev/null 2>&1 && { echo "Release ${TAG} already exists. Skipping creation." >&2; exit 0; }
           gh release create "${TAG}" --title "${TAG}" --generate-notes "${FLAGS[@]}" || { echo "Failed to create release ${TAG}. Check if tag exists or permissions are missing."; exit 1; }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,6 @@ jobs:
         run: |
           FLAGS=()
           if [ "${DRAFT}" = "true" ]; then FLAGS+=("--draft"); fi
-          if [[ ! "${TAG}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.-]+)?(\+[A-Za-z0-9.-]+)?$ ]]; then echo "Invalid tag format: ${TAG}. Expected format: v1.2.3 or v1.2.3-alpha.1"; exit 1; fi
+          if [[ ! "${TAG}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.-]+)?(\+[A-Za-z0-9.-]+)?$ ]]; then echo "Invalid tag format: ${TAG}. Expected semantic version format: v1.2.3, v1.2.3-alpha.1, or v1.2.3+build.1"; exit 1; fi
           gh release view "${TAG}" >/dev/null 2>&1 && { echo "Release ${TAG} already exists. Skipping creation."; exit 0; }
           gh release create "${TAG}" --title "${TAG}" --generate-notes "${FLAGS[@]}" || { echo "Failed to create release ${TAG}. Check if tag exists or permissions are missing."; exit 1; }


### PR DESCRIPTION
Extend the Pull Request Review workflow to auto-resolve threads when suggested changes have been applied.

- Trigger on synchronize so it re-checks after new commits
- Use actions/github-script with GraphQL:
  - List open review threads
  - For suggestion-style comments (```suggestion ...```), compare suggestion text to current file at PR head
  - If suggestion now exists verbatim, resolve the review thread

Conservative behavior (only resolves when suggestion matches exactly). Can be further gated by label or author if desired.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Automatically resolves addressed “suggestion” review threads in pull requests, validating suggestions against the latest code with safety checks and clear logging.
  - Adds a Release workflow to create GitHub releases from tags or on demand, supporting draft releases, semantic version enforcement, and idempotent behaviour.

- Chores
  - Expanded pull request triggers to include synchronise events for improved CI responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->